### PR TITLE
sparkwarc should unload its shared library in `.onUnload()`

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -15,3 +15,7 @@ spark_dependencies <- function(spark_version, scala_version, ...) {
 .onLoad <- function(libname, pkgname) {
   sparklyr::register_extension(pkgname)
 }
+
+.onUnload <- function(libpath) {
+  library.dynam.unload("sparkwarc", libpath)
+}


### PR DESCRIPTION
As titled, when `sparkwarc` is attached, on Linux one should be able to find `sparkwarc.so` in the virtual memory of the R process (i.e., `/proc/<the R process PID>/maps`), and when it's detached with `detach("package:sparkwarc", unload = TRUE)`, `sparkwarc.so` should be unloaded from the virtual memory of the R process accordingly (so it should no longer show up in `/proc/<the R process PID>/maps`).

Signed-off-by: Yitao Li <yitao@rstudio.com>